### PR TITLE
Fix LoopIfElseMergeTest testcase.

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -3325,14 +3325,17 @@ public class MustCallConsistencyAnalyzer {
         boolean isLastBlockOfBody = successorAndExceptionType.first == loopUpdateBlock;
         if (isLastBlockOfBody) {
           Set<String> calledMethodsAfterBlock =
-              analyzeTypeOfCollectionElement(currentBlock, potentiallyFulfillingLoop, obligations);
+              analyzeTypeOfCollectionElement(
+                  currentBlock, potentiallyFulfillingLoop, obligations, loopUpdateBlock);
           // intersect the called methods after this block with the accumulated ones so far.
           // This is required because there may be multiple "back edges" of the loop, in which
           // case we must intersect the called methods between those.
-          if (calledMethodsInLoop == null) {
-            calledMethodsInLoop = calledMethodsAfterBlock;
-          } else {
-            calledMethodsInLoop.retainAll(calledMethodsAfterBlock);
+          if (calledMethodsAfterBlock != null) {
+            if (calledMethodsInLoop == null) {
+              calledMethodsInLoop = calledMethodsAfterBlock;
+            } else {
+              calledMethodsInLoop.retainAll(calledMethodsAfterBlock);
+            }
           }
         } else {
           try {
@@ -3367,15 +3370,21 @@ public class MustCallConsistencyAnalyzer {
    * @param lastLoopBodyBlock last block of loop body
    * @param potentiallyFulfillingLoop loop wrapper of the loop to analyze
    * @param obligations the set of tracked obligations
+   * @param loopUpdateBlock block that updates the loop
    * @return the union of methods in the CalledMethods type of the collection element and all its
-   *     resource aliases.
+   *     resource aliases or {@code null} if the called methods is bottom
    */
   private Set<String> analyzeTypeOfCollectionElement(
       Block lastLoopBodyBlock,
       PotentiallyFulfillingLoop potentiallyFulfillingLoop,
-      Set<Obligation> obligations) {
+      Set<Obligation> obligations,
+      Block loopUpdateBlock) {
     AccumulationStore store = null;
-    if (lastLoopBodyBlock.getLastNode() == null) {
+    if (lastLoopBodyBlock.getType() == BlockType.CONDITIONAL_BLOCK) {
+      ConditionalBlock conditionalBlock = (ConditionalBlock) lastLoopBodyBlock;
+      boolean thenSuccessor = conditionalBlock.getThenSuccessor() == loopUpdateBlock;
+      store = cmAtf.getStoreAfterConditionalBlock(conditionalBlock, thenSuccessor);
+    } else if (lastLoopBodyBlock.getLastNode() == null) {
       // TODO is this really the right store? I think we need to get the then-or else store
       store = cmAtf.getStoreAfterBlock(lastLoopBodyBlock);
     } else {
@@ -3393,7 +3402,7 @@ public class MustCallConsistencyAnalyzer {
       //         + potentiallyFulfillingLoop.collectionElementTree);
     }
 
-    Set<String> calledMethodsAfterThisBlock = new HashSet<>();
+    Set<String> calledMethodsAfterThisBlock = null;
 
     // add the called methods of the ICE
     IteratedCollectionElement ice =
@@ -3403,18 +3412,24 @@ public class MustCallConsistencyAnalyzer {
     if (ice != null) {
       AccumulationValue cmValOfIce = store.getValue(ice);
       List<String> calledMethods = getCalledMethods(cmValOfIce);
-      if (calledMethods != null && calledMethods.size() > 0) {
-        calledMethodsAfterThisBlock.addAll(calledMethods);
+      if (calledMethods != null) {
+        calledMethodsAfterThisBlock = new HashSet<>(calledMethods);
       }
     }
 
     // add the called methods of possible aliases of the collection element
     for (ResourceAlias alias : collectionElementObligation.resourceAliases) {
       AccumulationValue cmValOfAlias = store.getValue(alias.reference);
-      if (cmValOfAlias == null) continue;
+      if (cmValOfAlias == null) {
+        continue;
+      }
       List<String> calledMethods = getCalledMethods(cmValOfAlias);
-      if (calledMethods != null && calledMethods.size() > 0) {
-        calledMethodsAfterThisBlock.addAll(calledMethods);
+      if (calledMethods != null) {
+        if (calledMethodsAfterThisBlock == null) {
+          calledMethodsAfterThisBlock = new HashSet<>(calledMethods);
+        } else {
+          calledMethodsAfterThisBlock.addAll(calledMethods);
+        }
       }
     }
 
@@ -3422,10 +3437,12 @@ public class MustCallConsistencyAnalyzer {
   }
 
   /**
-   * Returns the set of called methods values given an AccumulationValue.
+   * Returns the set of called methods values given an AccumulationValue or null if the accumulation
+   * value is bottom.
    *
    * @param cmVal the accumulation value
-   * @return the set of called methods of the given value
+   * @return the set of called methods of the given value or null * if the accumulation value is
+   *     bottom
    */
   private List<String> getCalledMethods(AccumulationValue cmVal) {
     Set<String> calledMethods = cmVal.getAccumulatedValues();
@@ -3436,6 +3453,9 @@ public class MustCallConsistencyAnalyzer {
         if (AnnotationUtils.areSameByName(
             anno, "org.checkerframework.checker.calledmethods.qual.CalledMethods")) {
           return cmAtf.getCalledMethods(anno);
+        } else if (AnnotationUtils.areSameByName(
+            anno, "org.checkerframework.checker.calledmethods.qual.CalledMethodsBottom")) {
+          return null;
         }
       }
     }

--- a/checker/src/main/java/org/checkerframework/checker/rlccalledmethods/RLCCalledMethodsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/rlccalledmethods/RLCCalledMethodsAnnotatedTypeFactory.java
@@ -433,6 +433,24 @@ public class RLCCalledMethodsAnnotatedTypeFactory extends CalledMethodsAnnotated
     return flowResult.getStoreAfter(block);
   }
 
+  /**
+   * Returns the then or else store after {@code block} depending on the value of {@code then} is
+   * returned.
+   *
+   * @param block a conditional block
+   * @param then wether the then store should be returned
+   * @return the then or else store after {@code block} depending on the value of {@code then} is
+   *     returned
+   */
+  public AccumulationStore getStoreAfterConditionalBlock(ConditionalBlock block, boolean then) {
+    TransferInput<AccumulationValue, AccumulationStore> transferInput = flowResult.getInput(block);
+    assert transferInput != null : "@AssumeAssertion(nullness): transferInput should be non-null";
+    if (then) {
+      return transferInput.getThenStore();
+    }
+    return transferInput.getElseStore();
+  }
+
   @Override
   @SuppressWarnings("TypeParameterUnusedInFormals") // Intentional abuse
   public <T extends GenericAnnotatedTypeFactory<?, ?, ?, ?>>


### PR DESCRIPTION
Two bugs I fixed:

1. In `analyzeTypeOfCollectionElement`, the then and else stores were merged when instead only one should be used.
2.  In places where a set for called methods were returns, `@CalledMethodsBottom` was treated the same as top, i.e. an empty set was returned.  I changed this so that `null` was returned instead.